### PR TITLE
Call handle_disconnected for all client terminations

### DIFF
--- a/src/mqtt_client.erl
+++ b/src/mqtt_client.erl
@@ -451,7 +451,8 @@ handle_event(Event, State=#?STATE{handler=Handler}) ->
 terminate(normal, State=#?STATE{state=disconnecting, handler=Handler}) ->
 	Handler:handle_disconnected(State#?STATE.handler_state),
 	normal;
-terminate(Reason, _State) ->
+terminate(Reason, State=#?STATE{handler=Handler}) ->
+	Handler:handle_disconnected(State#?STATE.handler_state),
 	Reason.
 
 %%


### PR DESCRIPTION
If you restart mqtt broker, connection is closed,
mqtt_protocol terminates with reason "normal" and handle_disconnected
is not called. I.e. client code is not informed about connection
termination.

I thing this is bad. Maybe you should use this simplest solution or terminate protocol
with some other reason (tcp_closed?) whenever unexpected tcp disconnect occurs.
